### PR TITLE
refactor: RunRecord 타입을 사용하여 차트 컴포넌트의 기록 타입 통일

### DIFF
--- a/web/components/calendar/CalendarCells.tsx
+++ b/web/components/calendar/CalendarCells.tsx
@@ -10,7 +10,7 @@ import {
   isSameMonth,
   isSameDay
 } from 'date-fns';
-import { RunRecord } from '@/components/calendar/Calendar';
+import { RunRecord } from '@/types/runningTypes';
 import { twMerge } from 'tailwind-merge';
 import { motion } from 'framer-motion';
 

--- a/web/components/calendar/Chart/DistanceChart.tsx
+++ b/web/components/calendar/Chart/DistanceChart.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Chart from './Chart';
-import { CalendarRecords } from '@/hooks/queries/calendar/useCalendarRecords';
+import { RunRecord } from '@/types/runningTypes';
 import { processRecordsForChart } from '@/utils/charts';
 
 interface DistanceChartProps {
-  records: CalendarRecords['histories'];
+  records: RunRecord[];
 }
 
 export default function DistanceChart({ records }: DistanceChartProps) {

--- a/web/components/calendar/Chart/PaceChart.tsx
+++ b/web/components/calendar/Chart/PaceChart.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Chart from './Chart';
-import { CalendarRecords } from '@/hooks/queries/calendar/useCalendarRecords';
+import { RunRecord } from '@/types/runningTypes';
 import { processRecordsForChart } from '@/utils/charts';
 
 interface PaceChartProps {
-  records: CalendarRecords['histories'];
+  records: RunRecord[];
 }
 
 export default function PaceChart({ records }: PaceChartProps) {

--- a/web/components/calendar/Chart/TimeChart.tsx
+++ b/web/components/calendar/Chart/TimeChart.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Chart from './Chart';
-import { CalendarRecords } from '@/hooks/queries/calendar/useCalendarRecords';
+import { RunRecord } from '@/types/runningTypes';
 import { processRecordsForChart } from '@/utils/charts';
 
 interface TimeChartProps {
-  records: CalendarRecords['histories'];
+  records: RunRecord[];
 }
 
 export default function TimeChart({ records }: TimeChartProps) {

--- a/web/hooks/queries/calendar/useCalendarRecords.ts
+++ b/web/hooks/queries/calendar/useCalendarRecords.ts
@@ -1,14 +1,11 @@
 import { getMonthlyCalendar, getWeeklyCalendar } from '@/utils/apis/calendar';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { RunRecord } from '@/types/runningTypes';
 
 export type CalendarRecords = {
   totalDistance: number;
   totalDuration: number;
-  histories: {
-    date: string;
-    distance: number;
-    duration: number;
-  }[];
+  histories: RunRecord[];
 };
 
 export const useCalendarRecords = (
@@ -29,9 +26,7 @@ export const useCalendarRecords = (
   const mondayDateString = monday.toISOString().split('T')[0];
 
   const dateForQueryKey =
-    view === 'week'
-      ? mondayDateString
-      : `${year}-${month}`;
+    view === 'week' ? mondayDateString : `${year}-${month}`;
 
   return useQuery<CalendarRecords, Error>({
     queryKey: ['calendarRecords', view, year, month, dateForQueryKey],
@@ -41,6 +36,6 @@ export const useCalendarRecords = (
       }
       return getMonthlyCalendar(year, month);
     },
-    ...options,
+    ...options
   });
 };

--- a/web/types/runningTypes.ts
+++ b/web/types/runningTypes.ts
@@ -19,5 +19,11 @@ interface EndRunningPostData {
     pointCount: number;
   };
 }
+//캘린더 쪽
+type RunRecord = {
+  date: string;
+  distance: number;
+  duration: number;
+};
 
-export type { RunningData, EndRunningPostData };
+export type { RunningData, EndRunningPostData, RunRecord };


### PR DESCRIPTION
## What is this PR? :mag:
RunRecord 타입 오류 수정(캘린더 차트 컴포넌트 수정 및 types/runningType에  RunRecord 타입 추가)
## Changes :memo:

## Screenshot :camera:
